### PR TITLE
feat: Implement Edit API Specification Name

### DIFF
--- a/src/app/api/documents/[docId]/route.ts
+++ b/src/app/api/documents/[docId]/route.ts
@@ -1,0 +1,27 @@
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function PATCH(request: Request, { params }: { params: { docId: string } }) {
+  const docId = params.docId;
+  const { newName } = await request.json();
+
+  if (!newName) {
+    return NextResponse.json({ message: "New name is required" }, { status: 400 });
+  }
+
+  try {
+    const updatedDocument = await prisma.apiDocument.update({
+      where: {
+        id: docId,
+      },
+      data: {
+        name: newName,
+      },
+    });
+    return NextResponse.json({ message: "Document name updated successfully", updatedDocument }, { status: 200 });
+  } catch (error) {
+    console.error("Error updating document name:", error);
+    return NextResponse.json({ message: "Failed to update document name" }, { status: 500 });
+  }
+}

--- a/src/app/projects/[id]/docs/[docId]/page.tsx
+++ b/src/app/projects/[id]/docs/[docId]/page.tsx
@@ -6,6 +6,8 @@ import { useParams } from "next/navigation";
 import SwaggerUI from "swagger-ui-react";
 import "swagger-ui-react/swagger-ui.css";
 import * as jsyaml from "js-yaml";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface ApiDocument {
   id: string;
@@ -21,6 +23,8 @@ export default function ApiDocumentDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [spec, setSpec] = useState<any>(null);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [editedName, setEditedName] = useState("");
 
   useEffect(() => {
     if (!projectId || !docId) return;
@@ -60,6 +64,47 @@ export default function ApiDocumentDetailPage() {
     fetchApiDocument();
   }, [projectId, docId]);
 
+  useEffect(() => {
+    if (apiDocument) {
+      setEditedName(apiDocument.name);
+    }
+  }, [apiDocument]);
+
+  const handleSaveName = async () => {
+    if (!editedName.trim()) {
+      alert("Document name cannot be empty.");
+      return;
+    }
+    try {
+      const response = await fetch(`/api/documents/${docId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ newName: editedName }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to update document name.");
+      }
+
+      const result = await response.json();
+      console.log("Name update successful:", result);
+      setApiDocument((prevDoc) => (prevDoc ? { ...prevDoc, name: editedName } : null));
+      setIsEditingName(false);
+    } catch (err: any) {
+      console.error("Error updating name:", err);
+      alert(`Error updating name: ${err.message}`);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditingName(false);
+    if (apiDocument) {
+      setEditedName(apiDocument.name);
+    }
+  };
+
   if (loading) {
     return <div className="text-center">Loading API document...</div>;
   }
@@ -74,7 +119,28 @@ export default function ApiDocumentDetailPage() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold mb-4">API Document: {apiDocument.name}</h1>
+      <div className="flex items-center gap-2 mb-4">
+        {isEditingName ? (
+          <Input
+            value={editedName}
+            onChange={(e) => setEditedName(e.target.value)}
+            className="flex-grow"
+          />
+        ) : (
+          <h1 className="text-3xl font-bold">API Document: {apiDocument.name}</h1>
+        )}
+        {!isEditingName && (
+          <Button onClick={() => setIsEditingName(true)} size="sm" variant="outline">
+            Edit
+          </Button>
+        )}
+        {isEditingName && (
+          <div className="flex gap-2">
+            <Button onClick={handleSaveName} size="sm">Save</Button>
+            <Button onClick={handleCancelEdit} size="sm" variant="outline">Cancel</Button>
+          </div>
+        )}
+      </div>
       <SwaggerUI spec={spec} />
     </div>
   );


### PR DESCRIPTION
This PR implements the feature to edit the name of an API specification as described in issue #4.\n\nKey changes include:\n- UI for editing the API document name on the detail page.\n- Backend API to update the API document name in the database.